### PR TITLE
📦 refactor: 使用 `pako` 替换 `node:zlib` 以兼容浏览器环境

### DIFF
--- a/sdk/ts/package-lock.json
+++ b/sdk/ts/package-lock.json
@@ -6,13 +6,15 @@
   "packages": {
     "": {
       "name": "@seerbp/petcode-sdk",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
-        "@bufbuild/protobuf": "^2.10.2"
+        "@bufbuild/protobuf": "^2.10.2",
+        "pako": "^2.1.0"
       },
       "devDependencies": {
         "@types/node": "^22.10.2",
+        "@types/pako": "^2.0.4",
         "rimraf": "^6.0.1",
         "tsx": "^4.21.0",
         "typescript": "^5.9.3"
@@ -499,6 +501,13 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/esbuild": {
       "version": "0.27.2",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.2.tgz",
@@ -629,6 +638,12 @@
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "dev": true,
       "license": "BlueOak-1.0.0"
+    },
+    "node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
+      "license": "(MIT AND Zlib)"
     },
     "node_modules/path-scurry": {
       "version": "2.0.1",

--- a/sdk/ts/package.json
+++ b/sdk/ts/package.json
@@ -18,6 +18,7 @@
   "type": "module",
   "exports": {
     ".": "./dist/index.js",
+    "./*.js": "./dist/*.js",
     "./dist/*.js": "./dist/*.js",
     "./pb/*.js": "./dist/generated/seerbp/petcode/*.js"
   },
@@ -34,11 +35,13 @@
   },
   "devDependencies": {
     "@types/node": "^22.10.2",
+    "@types/pako": "^2.0.4",
     "rimraf": "^6.0.1",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3"
   },
   "dependencies": {
-    "@bufbuild/protobuf": "^2.10.2"
+    "@bufbuild/protobuf": "^2.10.2",
+    "pako": "^2.1.0"
   }
 }

--- a/sdk/ts/src/index.ts
+++ b/sdk/ts/src/index.ts
@@ -5,7 +5,15 @@ import {
   type MessageShape, type DescMessage, toJson as schemaToJson, fromJson as schemaFromJson,
   type MessageJsonType,
 } from "@bufbuild/protobuf";
-import { gzipSync, unzipSync } from 'node:zlib';
+import { gzip, ungzip } from "pako";
+
+function compressWithGzip(binary: Uint8Array) {
+  return gzip(binary, { level: 1 });
+}
+
+function decompressWithGzip(binary: Uint8Array) {
+  return ungzip(binary);
+}
 
 /**
  * 将消息对象转换为二进制数据
@@ -14,7 +22,7 @@ import { gzipSync, unzipSync } from 'node:zlib';
  * @returns 二进制数据
  */
 export function toBinary<T extends DescMessage>(schema: T, message: MessageShape<T>): Uint8Array {
-  return gzipSync(schemaToBinary(schema, message), { level: 1 });
+  return compressWithGzip(schemaToBinary(schema, message));
 }
 
 /**
@@ -24,7 +32,7 @@ export function toBinary<T extends DescMessage>(schema: T, message: MessageShape
  * @returns 消息对象
  */
 export function fromBinary<T extends DescMessage>(schema: T, binary: Uint8Array): MessageShape<T> {
-  return schemaFromBinary(schema, unzipSync(binary));
+  return schemaFromBinary(schema, decompressWithGzip(binary));
 }
 
 /**

--- a/sdk/ts/test/index.test.ts
+++ b/sdk/ts/test/index.test.ts
@@ -36,7 +36,18 @@ describe("index (序列化和反序列化)", () => {
     seerSet: {},
   });
 
+  const testMessageBase64 = "H4sIAOIQWmkE/x3MoQ7CMBSFYW63lbua3RRB0xBYNkOmyAweiWnCM6AmeQU0dijwJBXMgRwPwLsggIEZHeL7c9RBINADET2teVnztqax5mMN5ckJ8D6ktZrEkHFsgVrIo3MJhxK2NexqOJawCHHfHbBxb4maY31hFPzXrVurTHBMKVWpZDSXPnISrn2S2kcg4cr+DUgUI2RSCYZCOtpJnMzJnQKRS9+9BBuJ15AaX1Ve/IVp5c0e7Ae/eGDrxQAAAA=="
+
   describe("toBinary 和 fromBinary", () => {
+    it("应该将 Base64 字符串还原为消息对象", () => {
+      const restored = fromBase64(PetCodeMessageSchema, testMessageBase64);
+      assert.equal(restored.server, testMessage.server);
+      assert.equal(restored.displayMode, testMessage.displayMode);
+      assert.equal(restored.pets.length, 1);
+      assert.equal(restored.pets[0]?.id, 3022);
+      assert.equal(restored.pets[0]?.level, 100);
+    });
+
     it("应该将消息转换为二进制并能够还原", () => {
       const binary = toBinary(PetCodeMessageSchema, testMessage);
       assert.ok(binary instanceof Uint8Array);


### PR DESCRIPTION
## 📝 变更描述

替换 `ts-sdk` 中的 `node:zlib` 以兼容浏览器环境，为浏览器示例做准备

## 🎯 变更类型

- [x] ♻️ 代码重构

## 🔍 影响范围

- [ ] Server (`server/`)
- [x] SDK (`sdk/`)
- [ ] Protocol Buffers (`proto`)
- [ ] GitHub Actions 工作流
- [ ] 文档
- [ ] 其他（请说明）：

## 🧪 测试

- [x] 已添加新的测试用例
- [ ] 已通过现有测试
- [ ] 已手动测试
- [ ] 不需要测试

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Moves TS SDK compression from `node:zlib` to `pako` for browser compatibility and updates tests and packaging accordingly.
> 
> - Replace `gzipSync/unzipSync` with `pako`’s `gzip/ungzip` via `compressWithGzip`/`decompressWithGzip` in `src/index.ts`
> - Add tests validating Base64 decode/encode and round-trip serialization using `pako` (`test/index.test.ts`)
> - Update `package.json` exports to include `"./*.js"`, add deps `pako` and `@types/pako`
> - Lockfile updates (version bump to 1.0.2, new deps)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 74bb41552fa1209a5fbadfcfae548edfd76086ad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->