### PR TITLE
📦 refactor(proto): 将 PetCodeMessage 中的 title_id 字段修改为显式可选字段

### DIFF
--- a/docs/data-structure.md
+++ b/docs/data-structure.md
@@ -245,7 +245,7 @@
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | equips | [int32](#int32) | repeated | 装备部件ID列表 |
-| title_id | [int32](#int32) |  | 称号ID，对应游戏配置文件`achievements`中的`spe_name_bonus`字段 |
+| title_id | [int32](#int32) | optional | 称号ID，对应游戏配置文件`achievements`中的`spe_name_bonus`字段 |
 
 
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -463,10 +463,13 @@ components:
           title: equips
           description: 装备部件ID列表
         titleId:
-          type: integer
+          type:
+            - integer
+            - "null"
           title: title_id
           format: int32
           description: 称号ID，对应游戏配置文件`achievements`中的`spe_name_bonus`字段
+          nullable: true
       title: SeerSet
       additionalProperties: false
     seerbp.petcode.v1.PetCodeMessage.Server:

--- a/proto/seerbp/petcode/v1/message.proto
+++ b/proto/seerbp/petcode/v1/message.proto
@@ -211,7 +211,7 @@ message PetCodeMessage {
     // 装备部件ID列表
     repeated int32 equips = 1;
     // 称号ID，对应游戏配置文件`achievements`中的`spe_name_bonus`字段
-    int32 title_id = 2;
+    optional int32 title_id = 2;
   }
   // 服务器标记，用于指示接收方需要使用的数据源
   Server server = 1;


### PR DESCRIPTION
## 📝 变更描述

之前的版本中，`PetCodeMessage` 中的 `title_id` 字段是隐式可选的，意味着在部分运行时环境中，当没有设置称号时，该值可能为0

## 🎯 变更类型

- [x] 📝 文档更新
- [x] ♻️ 代码重构

## 🔍 影响范围

请勾选受影响的组件：

- [ ] Server (`server/`)
- [ ] SDK (`sdk/`)
- [x] Protocol Buffers (`proto`)
- [ ] GitHub Actions 工作流
- [ ] 文档
- [ ] 其他（请说明）：

## 🧪 测试

- [ ] 已添加新的测试用例
- [x] 已通过现有测试
- [ ] 已手动测试
- [ ] 不需要测试

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Protocol change**
> 
> - In `message.proto`, `PetCodeMessage.SeerSet.title_id` is now `optional int32`.
> 
> **API schema/docs updates**
> 
> - `openapi.yaml`: `seerbp.petcode.v1.PetCodeMessage.SeerSet.titleId` now `integer|null` with `nullable: true`.
> - Regenerated `docs/data-structure.md` to reflect `title_id` as optional.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8ae005256e240a1af5ab8e8a65558373c1dd5728. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->