### PR TITLE
✨ feat(proto): 添加战斗火焰相关字段

### DIFF
--- a/docs/data-structure.md
+++ b/docs/data-structure.md
@@ -26,6 +26,7 @@
     - [ResistanceInfo.StateItem](#seerbp-petcode-v1-ResistanceInfo-StateItem)
   
     - [PetAbilityBonus.Type](#seerbp-petcode-v1-PetAbilityBonus-Type)
+    - [PetCodeMessage.BattleFire](#seerbp-petcode-v1-PetCodeMessage-BattleFire)
     - [PetCodeMessage.DisplayMode](#seerbp-petcode-v1-PetCodeMessage-DisplayMode)
     - [PetCodeMessage.Server](#seerbp-petcode-v1-PetCodeMessage-Server)
   
@@ -230,6 +231,7 @@
 | display_mode | [PetCodeMessage.DisplayMode](#seerbp-petcode-v1-PetCodeMessage-DisplayMode) |  | 信息展示模式，用于指示接收方应该如何展示精灵信息 |
 | seer_set | [PetCodeMessage.SeerSet](#seerbp-petcode-v1-PetCodeMessage-SeerSet) |  | 套装和称号信息 |
 | pets | [PetInfo](#seerbp-petcode-v1-PetInfo) | repeated | 精灵信息列表 |
+| battle_fires | [PetCodeMessage.BattleFire](#seerbp-petcode-v1-PetCodeMessage-BattleFire) | repeated | 战斗火焰效果列表，设置为数组类型以兼容多合一战斗火焰。 |
 
 
 
@@ -365,6 +367,21 @@
 | TYPE_AWAKEN | 5 | 神谕觉醒 |
 | TYPE_SPECIAL | 6 | 特殊加成 |
 | TYPE_OTHER | 99 | 其他 |
+
+
+
+<a name="seerbp-petcode-v1-PetCodeMessage-BattleFire"></a>
+
+### PetCodeMessage.BattleFire
+战斗火焰枚举
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| BATTLE_FIRE_UNSPECIFIED | 0 |  |
+| BATTLE_FIRE_GREEN | 1 | 绿火 |
+| BATTLE_FIRE_BLUE | 2 | 蓝火 |
+| BATTLE_FIRE_PURPLE | 3 | 紫火 |
+| BATTLE_FIRE_GOLD | 4 | 金火 |
 
 
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -441,8 +441,24 @@ components:
             $ref: '#/components/schemas/seerbp.petcode.v1.PetInfo'
           title: pets
           description: 精灵信息列表
+        battleFires:
+          type: array
+          items:
+            $ref: '#/components/schemas/seerbp.petcode.v1.PetCodeMessage.BattleFire'
+          title: battle_fires
+          description: 战斗火焰效果列表，设置为数组类型以兼容多合一战斗火焰。
       title: PetCodeMessage
       additionalProperties: false
+    seerbp.petcode.v1.PetCodeMessage.BattleFire:
+      type: string
+      title: BattleFire
+      enum:
+        - BATTLE_FIRE_UNSPECIFIED
+        - BATTLE_FIRE_GREEN
+        - BATTLE_FIRE_BLUE
+        - BATTLE_FIRE_PURPLE
+        - BATTLE_FIRE_GOLD
+      description: 战斗火焰枚举
     seerbp.petcode.v1.PetCodeMessage.DisplayMode:
       type: string
       title: DisplayMode

--- a/proto/seerbp/petcode/v1/message.proto
+++ b/proto/seerbp/petcode/v1/message.proto
@@ -213,6 +213,18 @@ message PetCodeMessage {
     // 称号ID，对应游戏配置文件`achievements`中的`spe_name_bonus`字段
     optional int32 title_id = 2;
   }
+  // 战斗火焰枚举
+  enum BattleFire {
+    BATTLE_FIRE_UNSPECIFIED = 0;
+    // 绿火
+    BATTLE_FIRE_GREEN = 1;
+    // 蓝火
+    BATTLE_FIRE_BLUE = 2;
+    // 紫火
+    BATTLE_FIRE_PURPLE = 3;
+    // 金火
+    BATTLE_FIRE_GOLD = 4;
+  }
   // 服务器标记，用于指示接收方需要使用的数据源
   Server server = 1;
   // 信息展示模式，用于指示接收方应该如何展示精灵信息
@@ -221,4 +233,6 @@ message PetCodeMessage {
   SeerSet seer_set = 3;
   // 精灵信息列表
   repeated PetInfo pets = 4;
+  // 战斗火焰效果列表，设置为数组类型以兼容多合一战斗火焰。
+  repeated BattleFire battle_fires = 5;
 }


### PR DESCRIPTION
## 📝 变更描述

添加战斗火焰字段，进一步增强PVE易用性

## 🎯 变更类型

- [ ] 🐛 Bug 修复
- [x] ✨ 新特性
- [ ] 📝 文档更新
- [ ] 🎨 代码风格调整（不影响代码逻辑）
- [ ] ♻️ 代码重构
- [ ] ⚡️ 性能优化
- [ ] ✅ 测试相关
- [ ] 🔧 配置/工具链变更
- [ ] 🚀 CI/CD 相关

## 🔍 影响范围

请勾选受影响的组件：

- [ ] Server (`server/`)
- [ ] SDK (`sdk/`)
- [x] Protocol Buffers (`proto`)
- [ ] GitHub Actions 工作流
- [ ] 文档
- [ ] 其他（请说明）：

## 🧪 测试

- [ ] 已添加新的测试用例
- [x] 已通过现有测试
- [x] 已手动测试
- [ ] 不需要测试



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces battle fire support in the protocol and public schema.
> 
> - Adds `PetCodeMessage.BattleFire` enum (`GREEN/BLUE/PURPLE/GOLD`) in `message.proto`
> - Adds repeated `battle_fires` field to `PetCodeMessage` to support multiple battle fire effects
> - Updates `docs/data-structure.md` and `openapi.yaml` to document the new enum and field
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0b753dddfc8ab5bd1d48cde1de00b38437461770. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->