### PR TITLE
🎨 chore: 更新版本到1.1.0

### DIFF
--- a/sdk/py/petcode/create_and_read.py
+++ b/sdk/py/petcode/create_and_read.py
@@ -98,10 +98,12 @@ def create_petcode_message(
     display_mode: PetCodeMessage.DisplayMode,
     seer_set: PetCodeMessage.SeerSet,
     pets: list[PetInfo],
+    battle_fires: list[PetCodeMessage.BattleFire] | None = None,
 ) -> PetCodeMessage:
     return PetCodeMessage(
         server=server,
         display_mode=display_mode,
         seer_set=seer_set,
         pets=pets,
+        battle_fires=battle_fires or [],
     )

--- a/sdk/py/pyproject.toml
+++ b/sdk/py/pyproject.toml
@@ -4,12 +4,12 @@ build-backend = "uv_build"
 
 [project]
 name = "petcode"
-version = "1.0.0"
+version = "1.1.0"
 description = "PetCode SDK for Python"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "seerbp-petcode-protocolbuffers-python==33.2.0.1.20251225073453+b0513d4afebb",
+    "seerbp-petcode-protocolbuffers-python==33.2.0.1.20260110152342+c9e05318fd42",
 ]
 
 [tool.uv.build-backend]

--- a/sdk/py/tests/test_create_and_read.py
+++ b/sdk/py/tests/test_create_and_read.py
@@ -1,7 +1,5 @@
 """测试辅助创建和读取函数"""
 
-import pytest
-
 from petcode.create_and_read import (
     create_ability_mintmark,
     create_petcode_message,
@@ -11,6 +9,7 @@ from petcode.create_and_read import (
     create_universal_mintmark,
     read_mintmark,
 )
+import pytest
 from seerbp.petcode.v1.message_pb2 import (
     MintmarkInfo,
     PetAbilityValue,
@@ -107,7 +106,12 @@ class TestUniversalMintmark:
     def test_create_universal_mintmark_with_ability(self):
         """测试带自定义能力值的全能刻印"""
         ability = PetAbilityValue(
-            hp=100, attack=120, defense=80, special_attack=90, special_defense=85, speed=110
+            hp=100,
+            attack=120,
+            defense=80,
+            special_attack=90,
+            special_defense=85,
+            speed=110,
         )
         mintmark = create_universal_mintmark(id=40001, level=5, ability=ability)
 
@@ -120,7 +124,12 @@ class TestUniversalMintmark:
     def test_create_universal_mintmark_with_gem_and_ability(self):
         """测试同时带宝石和能力值的全能刻印"""
         ability = PetAbilityValue(
-            hp=100, attack=120, defense=80, special_attack=90, special_defense=85, speed=110
+            hp=100,
+            attack=120,
+            defense=80,
+            special_attack=90,
+            special_defense=85,
+            speed=110,
         )
         mintmark = create_universal_mintmark(
             id=40001, level=5, gem_id=1800011, bind_skill_id=24708, ability=ability
@@ -207,7 +216,7 @@ class TestReadMintmark:
     def test_read_empty_mintmark(self):
         """测试读取空刻印"""
         mintmark = MintmarkInfo()
-        with pytest.raises(ValueError, match="Unknown mintmark type"):
+        with pytest.raises(ValueError, match='Unknown mintmark type'):
             read_mintmark(mintmark)
 
 
@@ -316,7 +325,9 @@ class TestCreatePetCodeMessage:
             )
             assert message.display_mode == mode
 
-    def test_create_petcode_message_multiple_pets(self, sample_pet_info, sample_seer_set):
+    def test_create_petcode_message_multiple_pets(
+        self, sample_pet_info, sample_seer_set
+    ):
         """测试多只宠物"""
         from seerbp.petcode.v1.message_pb2 import PetAbilityValue, PetInfo
 
@@ -325,7 +336,12 @@ class TestCreatePetCodeMessage:
             level=100,
             dv=31,
             ability_total=PetAbilityValue(
-                hp=110, attack=130, defense=90, special_attack=100, special_defense=95, speed=120
+                hp=110,
+                attack=130,
+                defense=90,
+                special_attack=100,
+                special_defense=95,
+                speed=120,
             ),
         )
 
@@ -362,10 +378,20 @@ class TestCreatePetCodeMessage:
             level=100,
             dv=31,
             ability_total=PetAbilityValue(
-                hp=100, attack=120, defense=80, special_attack=90, special_defense=85, speed=110
+                hp=100,
+                attack=120,
+                defense=80,
+                special_attack=90,
+                special_defense=85,
+                speed=110,
             ),
             evs=PetAbilityValue(
-                hp=255, attack=255, defense=255, special_attack=255, special_defense=255, speed=255
+                hp=255,
+                attack=255,
+                defense=255,
+                special_attack=255,
+                special_defense=255,
+                speed=255,
             ),
             effects=[PetInfo.Effect(id=67, status=1, args=[1, 5])],
             skills=[24708, 31567, 31568, 31569],
@@ -373,7 +399,9 @@ class TestCreatePetCodeMessage:
             nature=1,
         )
 
-        seer_set = PetCodeMessage.SeerSet(equips=[200001, 300001, 400001, 500001, 600001])
+        seer_set = PetCodeMessage.SeerSet(
+            equips=[200001, 300001, 400001, 500001, 600001]
+        )
 
         message = create_petcode_message(
             server=PetCodeMessage.Server.SERVER_OFFICIAL,
@@ -386,3 +414,44 @@ class TestCreatePetCodeMessage:
         assert len(message.pets[0].skills) == 4
         assert len(message.pets[0].mintmarks) == 1
         assert message.pets[0].mintmarks[0].WhichOneof('mintmark') == 'universal'
+
+    def test_create_petcode_message_with_battle_fires(
+        self, sample_pet_info, sample_seer_set
+    ):
+        """测试带战斗火焰的消息创建"""
+        battle_fires = [
+            PetCodeMessage.BattleFire.BATTLE_FIRE_GREEN,
+            PetCodeMessage.BattleFire.BATTLE_FIRE_BLUE,
+        ]
+        message = create_petcode_message(
+            server=PetCodeMessage.Server.SERVER_OFFICIAL,
+            display_mode=PetCodeMessage.DisplayMode.DISPLAY_MODE_PVP,
+            seer_set=sample_seer_set,
+            pets=[sample_pet_info],
+            battle_fires=battle_fires,
+        )
+
+        assert len(message.battle_fires) == 2
+        assert message.battle_fires[0] == PetCodeMessage.BattleFire.BATTLE_FIRE_GREEN
+        assert message.battle_fires[1] == PetCodeMessage.BattleFire.BATTLE_FIRE_BLUE
+
+    def test_create_petcode_message_with_all_battle_fires(
+        self, sample_pet_info, sample_seer_set
+    ):
+        """测试所有类型的战斗火焰"""
+        battle_fires = [
+            PetCodeMessage.BattleFire.BATTLE_FIRE_GREEN,
+            PetCodeMessage.BattleFire.BATTLE_FIRE_BLUE,
+            PetCodeMessage.BattleFire.BATTLE_FIRE_PURPLE,
+            PetCodeMessage.BattleFire.BATTLE_FIRE_GOLD,
+        ]
+        message = create_petcode_message(
+            server=PetCodeMessage.Server.SERVER_OFFICIAL,
+            display_mode=PetCodeMessage.DisplayMode.DISPLAY_MODE_PVP,
+            seer_set=sample_seer_set,
+            pets=[sample_pet_info],
+            battle_fires=battle_fires,
+        )
+
+        assert len(message.battle_fires) == 4
+        assert PetCodeMessage.BattleFire.BATTLE_FIRE_GOLD in message.battle_fires

--- a/sdk/py/uv.lock
+++ b/sdk/py/uv.lock
@@ -24,6 +24,54 @@ wheels = [
 ]
 
 [[package]]
+name = "gnostic-gnostic-protocolbuffers-pyi"
+version = "33.2.0.1.20230414000709+087bc8072ce4"
+source = { registry = "https://buf.build/gen/python" }
+dependencies = [
+    { name = "protobuf" },
+    { name = "types-protobuf" },
+]
+wheels = [
+    { url = "https://buf.build/gen/python/gnostic-gnostic-protocolbuffers-pyi/gnostic_gnostic_protocolbuffers_pyi-33.2.0.1.20230414000709+087bc8072ce4-py3-none-any.whl" },
+]
+
+[[package]]
+name = "gnostic-gnostic-protocolbuffers-python"
+version = "33.2.0.1.20230414000709+087bc8072ce4"
+source = { registry = "https://buf.build/gen/python" }
+dependencies = [
+    { name = "gnostic-gnostic-protocolbuffers-pyi" },
+    { name = "protobuf" },
+]
+wheels = [
+    { url = "https://buf.build/gen/python/gnostic-gnostic-protocolbuffers-python/gnostic_gnostic_protocolbuffers_python-33.2.0.1.20230414000709+087bc8072ce4-py3-none-any.whl" },
+]
+
+[[package]]
+name = "googleapis-googleapis-protocolbuffers-pyi"
+version = "33.2.0.1.20251126203132+004180b77378"
+source = { registry = "https://buf.build/gen/python" }
+dependencies = [
+    { name = "protobuf" },
+    { name = "types-protobuf" },
+]
+wheels = [
+    { url = "https://buf.build/gen/python/googleapis-googleapis-protocolbuffers-pyi/googleapis_googleapis_protocolbuffers_pyi-33.2.0.1.20251126203132+004180b77378-py3-none-any.whl" },
+]
+
+[[package]]
+name = "googleapis-googleapis-protocolbuffers-python"
+version = "33.2.0.1.20251126203132+004180b77378"
+source = { registry = "https://buf.build/gen/python" }
+dependencies = [
+    { name = "googleapis-googleapis-protocolbuffers-pyi" },
+    { name = "protobuf" },
+]
+wheels = [
+    { url = "https://buf.build/gen/python/googleapis-googleapis-protocolbuffers-python/googleapis_googleapis_protocolbuffers_python-33.2.0.1.20251126203132+004180b77378-py3-none-any.whl" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -43,7 +91,7 @@ wheels = [
 
 [[package]]
 name = "petcode"
-version = "1.0.0"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "seerbp-petcode-protocolbuffers-python" },
@@ -57,7 +105,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "seerbp-petcode-protocolbuffers-python", specifier = "==33.2.0.1.20251225073453+b0513d4afebb" }]
+requires-dist = [{ name = "seerbp-petcode-protocolbuffers-python", specifier = "==33.2.0.1.20260110152342+c9e05318fd42" }]
 
 [package.metadata.requires-dev]
 dev = [
@@ -145,26 +193,30 @@ wheels = [
 
 [[package]]
 name = "seerbp-petcode-protocolbuffers-pyi"
-version = "33.2.0.1.20251225073453+b0513d4afebb"
+version = "33.2.0.1.20260110152342+c9e05318fd42"
 source = { registry = "https://buf.build/gen/python" }
 dependencies = [
+    { name = "gnostic-gnostic-protocolbuffers-pyi" },
+    { name = "googleapis-googleapis-protocolbuffers-pyi" },
     { name = "protobuf" },
     { name = "types-protobuf" },
 ]
 wheels = [
-    { url = "https://buf.build/gen/python/seerbp-petcode-protocolbuffers-pyi/seerbp_petcode_protocolbuffers_pyi-33.2.0.1.20251225073453+b0513d4afebb-py3-none-any.whl" },
+    { url = "https://buf.build/gen/python/seerbp-petcode-protocolbuffers-pyi/seerbp_petcode_protocolbuffers_pyi-33.2.0.1.20260110152342+c9e05318fd42-py3-none-any.whl" },
 ]
 
 [[package]]
 name = "seerbp-petcode-protocolbuffers-python"
-version = "33.2.0.1.20251225073453+b0513d4afebb"
+version = "33.2.0.1.20260110152342+c9e05318fd42"
 source = { registry = "https://buf.build/gen/python" }
 dependencies = [
+    { name = "gnostic-gnostic-protocolbuffers-python" },
+    { name = "googleapis-googleapis-protocolbuffers-python" },
     { name = "protobuf" },
     { name = "seerbp-petcode-protocolbuffers-pyi" },
 ]
 wheels = [
-    { url = "https://buf.build/gen/python/seerbp-petcode-protocolbuffers-python/seerbp_petcode_protocolbuffers_python-33.2.0.1.20251225073453+b0513d4afebb-py3-none-any.whl" },
+    { url = "https://buf.build/gen/python/seerbp-petcode-protocolbuffers-python/seerbp_petcode_protocolbuffers_python-33.2.0.1.20260110152342+c9e05318fd42-py3-none-any.whl" },
 ]
 
 [[package]]

--- a/sdk/ts/package-lock.json
+++ b/sdk/ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@seerbp/petcode-sdk",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@seerbp/petcode-sdk",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@bufbuild/protobuf": "^2.10.2",

--- a/sdk/ts/package.json
+++ b/sdk/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@seerbp/petcode-sdk",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "PetCode SDK for TypeScript",
   "license": "MIT",
   "author": "Nattsu39 <Natsu39@outlook.com> (https://github.com/Nattsu39)",

--- a/sdk/ts/src/create_and_read.ts
+++ b/sdk/ts/src/create_and_read.ts
@@ -96,6 +96,7 @@ export function createStateResist(
  * @param displayMode - 显示模式
  * @param pets - 精灵列表
  * @param seerSet - 套装和称号信息
+ * @param battleFires - 战斗火焰效果列表
  * @returns `PetCodeMessage` 对象
  */
 export function createPetCodeMessage(
@@ -103,7 +104,8 @@ export function createPetCodeMessage(
   displayMode: PetCodeMessage_DisplayMode,
   pets: OmitTypeName<PetInfo>[],
   seerSet: PetCodeMessage_SeerSetJson = {},
+  battleFires: number[] = [],
 ): PetCodeMessage {
   const petMessages = pets.map(pet => create(PetInfoSchema, pet as any));
-  return create(PetCodeMessageSchema, { server, displayMode, seerSet, pets: petMessages });
+  return create(PetCodeMessageSchema, { server, displayMode, seerSet, pets: petMessages, battleFires });
 }

--- a/sdk/ts/test/create_and_read.test.ts
+++ b/sdk/ts/test/create_and_read.test.ts
@@ -9,7 +9,7 @@ import {
   createStateResist,
   createPetCodeMessage,
 } from "../src/create_and_read.js";
-import { PetCodeMessage_DisplayMode, PetCodeMessage_Server, PetInfoSchema, ResistanceInfoSchema } from "../src/generated/seerbp/petcode/v1/message_pb.js";
+import { PetCodeMessage_BattleFire, PetCodeMessage_DisplayMode, PetCodeMessage_Server, PetInfoSchema, ResistanceInfoSchema } from "../src/generated/seerbp/petcode/v1/message_pb.js";
 import { create } from "@bufbuild/protobuf";
 
 describe("create_and_read", () => {
@@ -235,6 +235,25 @@ describe("create_and_read", () => {
       assert.equal(message.pets.length, 2);
       assert.equal(message.pets[0]?.id, 123);
       assert.equal(message.pets[1]?.id, 456);
+    });
+
+    it("应该处理战斗火焰", () => {
+      const testPet = create(PetInfoSchema, { id: 123 });
+      const battleFires = [
+        PetCodeMessage_BattleFire.GREEN,
+        PetCodeMessage_BattleFire.GOLD,
+      ];
+      const message = createPetCodeMessage(
+        PetCodeMessage_Server.OFFICIAL,
+        PetCodeMessage_DisplayMode.PVP,
+        [testPet],
+        {},
+        battleFires
+      );
+
+      assert.equal(message.battleFires.length, 2);
+      assert.equal(message.battleFires[0], PetCodeMessage_BattleFire.GREEN);
+      assert.equal(message.battleFires[1], PetCodeMessage_BattleFire.GOLD);
     });
   });
 });

--- a/sdk/ts/test/index.test.ts
+++ b/sdk/ts/test/index.test.ts
@@ -8,7 +8,7 @@ import {
   toObject,
   fromObject,
 } from "../src/index.js";
-import { PetInfoSchema, PetCodeMessageSchema, PetCodeMessage_Server, PetCodeMessage_DisplayMode, ResistanceInfoSchema } from "../src/generated/seerbp/petcode/v1/message_pb.js";
+import { PetInfoSchema, PetCodeMessageSchema, PetCodeMessage_Server, PetCodeMessage_DisplayMode, ResistanceInfoSchema, PetCodeMessage_BattleFire } from "../src/generated/seerbp/petcode/v1/message_pb.js";
 import { create } from "@bufbuild/protobuf";
 import { createAbilityMintmark, createStateResist } from "../src/create_and_read.js";
 
@@ -178,6 +178,25 @@ describe("index (序列化和反序列化)", () => {
       assert.equal(originalJson.server, finalJson.server);
       assert.equal(originalJson.displayMode, finalJson.displayMode);
       assert.equal(originalJson.pets?.length, finalJson.pets?.length);
+    });
+  });
+
+  describe("战斗火焰序列化", () => {
+    it("应该正确转换带战斗火焰的消息", () => {
+      const message = create(PetCodeMessageSchema, {
+        server: PetCodeMessage_Server.OFFICIAL,
+        battleFires: [PetCodeMessage_BattleFire.GREEN, PetCodeMessage_BattleFire.BLUE],
+      });
+
+      const base64 = toBase64(PetCodeMessageSchema, message);
+      const restored = fromBase64(PetCodeMessageSchema, base64);
+      assert.equal(restored.battleFires.length, 2);
+      assert.ok(restored.battleFires.includes(PetCodeMessage_BattleFire.GREEN));
+      assert.ok(restored.battleFires.includes(PetCodeMessage_BattleFire.BLUE));
+
+      const json = toObject(PetCodeMessageSchema, message);
+      assert.ok(Array.isArray(json.battleFires));
+      assert.equal(json.battleFires.length, 2);
     });
   });
 });

--- a/server/ts/package-lock.json
+++ b/server/ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@seerbp/petcode-server",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@seerbp/petcode-server",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@bufbuild/buf": "^1.61.0",
@@ -16,7 +16,7 @@
         "@connectrpc/connect-fastify": "^2.1.1",
         "@connectrpc/connect-node": "^2.1.1",
         "@scalar/fastify-api-reference": "^1.40.9",
-        "@seerbp/petcode-sdk": "^1.0.1",
+        "@seerbp/petcode-sdk": "^1.1.0",
         "fastify": "^5.6.2"
       },
       "devDependencies": {
@@ -948,12 +948,13 @@
       }
     },
     "node_modules/@seerbp/petcode-sdk": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@seerbp/petcode-sdk/-/petcode-sdk-1.0.1.tgz",
-      "integrity": "sha512-fs/wRcZHTB8tnO1FxLlATFDUNyaLvjdXJGgUoZ3MtHl9DsNXvDiXyWlRhPy392DCrH7fuL5K6coAs/9A9kpZsg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@seerbp/petcode-sdk/-/petcode-sdk-1.1.0.tgz",
+      "integrity": "sha512-syAqKv5G2wB1qpN4Y13C+1SPjCgnCVkQPStJ3Im/IAYhRh55IV8ZfDzDpOqo6zDYVHX6/USTNFa3ffq37qnswA==",
       "license": "MIT",
       "dependencies": {
-        "@bufbuild/protobuf": "^2.10.2"
+        "@bufbuild/protobuf": "^2.10.2",
+        "pako": "^2.1.0"
       }
     },
     "node_modules/@types/node": {
@@ -989,6 +990,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -1474,6 +1476,12 @@
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "dev": true,
       "license": "BlueOak-1.0.0"
+    },
+    "node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
+      "license": "(MIT AND Zlib)"
     },
     "node_modules/path-scurry": {
       "version": "2.0.1",

--- a/server/ts/package.json
+++ b/server/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@seerbp/petcode-server",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "",
   "license": "MIT",
   "author": "Nattsu39",
@@ -33,7 +33,7 @@
     "@connectrpc/connect-fastify": "^2.1.1",
     "@connectrpc/connect-node": "^2.1.1",
     "@scalar/fastify-api-reference": "^1.40.9",
-    "@seerbp/petcode-sdk": "^1.0.1",
+    "@seerbp/petcode-sdk": "^1.1.0",
     "fastify": "^5.6.2"
   },
   "devDependencies": {


### PR DESCRIPTION
## 📝 变更描述

更新 SDK 和 Server 版本到1.1.0

## 🎯 变更类型

- [ ] 🐛 Bug 修复
- [ ] ✨ 新特性
- [ ] 📝 文档更新
- [ ] 🎨 代码风格调整（不影响代码逻辑）
- [ ] ♻️ 代码重构
- [ ] ⚡️ 性能优化
- [ ] ✅ 测试相关
- [ ] 🔧 配置/工具链变更
- [ ] 🚀 CI/CD 相关

## 🔍 影响范围

- [x] Server (`server/`)
- [x] SDK (`sdk/`)
- [ ] Protocol Buffers (`proto`)
- [ ] GitHub Actions 工作流
- [ ] 文档
- [ ] 其他（请说明）：

## 🧪 测试

- [x] 已添加新的测试用例
- [x] 已通过现有测试
- [ ] 已手动测试
- [ ] 不需要测试

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces BattleFire support and aligns versions across SDKs and server.
> 
> - Add optional `battle_fires`/`battleFires` to `create_petcode_message` (Python) and `createPetCodeMessage` (TypeScript), piping values into `PetCodeMessage`
> - Extend tests to cover message creation and (de)serialization of `battle_fires`/`battleFires` in `sdk/py/tests` and `sdk/ts/test`
> - Bump versions to `1.1.0` for `sdk/py`, `sdk/ts`, and `server/ts`; update Python dep `seerbp-petcode-protocolbuffers-python` to a newer build
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c18524172e400d498a41a9c801ba5e8f4f0ea104. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->